### PR TITLE
Bugfix/textarea

### DIFF
--- a/src/components/textarea-symbol-counter.js
+++ b/src/components/textarea-symbol-counter.js
@@ -10,10 +10,11 @@ function count(e) {
 }
 
 export function handleTextareaSymbolCounter() {
-  document.querySelectorAll('.textarea__field').forEach((textarea) => {      
-    if(!textarea.hasAttribute('maxlength')) return;
+  document.querySelectorAll('.textarea').forEach((textarea) => {    
+    if(!textarea.querySelector('.textarea__counter')) return;
     
-    textarea.addEventListener('input', (evt) => count(evt));
-    count(textarea);
+    const areaInput = textarea.querySelector('.textarea__field');
+    areaInput.addEventListener('input', (evt) => count(evt));
+    count(areaInput);
   })
 }

--- a/src/components/textarea-symbol-counter.js
+++ b/src/components/textarea-symbol-counter.js
@@ -10,7 +10,9 @@ function count(e) {
 }
 
 export function handleTextareaSymbolCounter() {
-  document.querySelectorAll('.textarea__field').forEach((textarea) => {    
+  document.querySelectorAll('.textarea__field').forEach((textarea) => {      
+    if(!textarea.hasAttribute('maxlength')) return;
+    
     textarea.addEventListener('input', (evt) => count(evt));
     count(textarea);
   })

--- a/src/lk-legal.html
+++ b/src/lk-legal.html
@@ -132,7 +132,7 @@
     </fieldset>
     <fieldset class="fieldset fieldset_template_grid-one-col fieldset_style_pb-small">   
         <div class="textarea">
-            <textarea class="textarea__field textarea__field_autosize" name="full-company-name" id="full-company-name"
+            <textarea class="textarea__field textarea__field_style_size-medium textarea__field_autosize" name="full-company-name" id="full-company-name"
                       placeholder="Полное название"
                       required></textarea>
             <label class="textarea__label" for="full-company-name">Полное название</label>
@@ -141,7 +141,7 @@
     </fieldset>
     <fieldset class="fieldset fieldset_template_grid-one-col">
         <div class="textarea">
-            <textarea class="textarea__field textarea__field_autosize" name="legal-address" id="legal-address"
+            <textarea class="textarea__field textarea__field_style_size-medium textarea__field_autosize" name="legal-address" id="legal-address"
                       placeholder="Юридический адрес"
                       required></textarea>
             <label class="textarea__label" for="legal-address">Юридический адрес</label>

--- a/src/registration-legal.html
+++ b/src/registration-legal.html
@@ -133,7 +133,7 @@
     </fieldset>
     <fieldset class="fieldset fieldset_template_grid-one-col fieldset_style_pb-small">   
         <div class="textarea">
-            <textarea class="textarea__field textarea__field_autosize" name="full-company-name" id="full-company-name"
+            <textarea class="textarea__field textarea__field_style_size-medium textarea__field_autosize " name="full-company-name" id="full-company-name"
                       placeholder="Полное название"
                       required></textarea>
             <label class="textarea__label" for="full-company-name">Полное название</label>
@@ -142,7 +142,7 @@
     </fieldset>
     <fieldset class="fieldset fieldset_template_grid-one-col">
         <div class="textarea">
-            <textarea class="textarea__field textarea__field_autosize" name="legal-address" id="legal-address"
+            <textarea class="textarea__field textarea__field_style_size-medium textarea__field_autosize" name="legal-address" id="legal-address"
                       placeholder="Юридический адрес"
                       required></textarea>
             <label class="textarea__label" for="legal-address">Юридический адрес</label>


### PR DESCRIPTION
Добавил стиль textarea__field_style_size-medium c ограничением высоты textarea в страницы registration-legal и lk-legal.
Ввел проверку ограничения по количеству символов в textarea-symbol-counter.js  

Пояснения: Проверка через нахождение стиля textarea__counter показалась довольно затруднительной из-за особенностей поиска полей textarea - этот блок находится вне textarea__field по которым идёт цикл. Так что я взял за основу проверки наличие атрибута ограничения количество символов.

- Вячеслав Попов.